### PR TITLE
Add language support for c++14.

### DIFF
--- a/cms/grading/languages/c++14_g++.py
+++ b/cms/grading/languages/c++14_g++.py
@@ -62,7 +62,7 @@ class Cpp14Gpp(CompiledLanguage):
         command = ["/usr/bin/g++"]
         if for_evaluation:
             command += ["-DEVAL"]
-        command += ["-std=c++14", "-O2", "-pipe", "-static",
+        command += ["-std=gnu++14", "-O2", "-pipe", "-static",
                     "-s", "-o", executable_filename]
         command += source_filenames
         return [command]

--- a/cms/grading/languages/c++14_g++.py
+++ b/cms/grading/languages/c++14_g++.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2016 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""C++ programming language definition."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from cms.grading import CompiledLanguage
+
+
+__all__ = ["Cpp14Gpp"]
+
+
+class Cpp14Gpp(CompiledLanguage):
+    """This defines the C++ programming language, compiled with g++ (the
+    version available on the system) using the C++14 standard.
+
+    """
+
+    @property
+    def name(self):
+        """See Language.name."""
+        return "C++14 / g++"
+
+    @property
+    def source_extensions(self):
+        """See Language.source_extensions."""
+        return [".cpp", ".cc", ".cxx", ".c++", ".C"]
+
+    @property
+    def header_extensions(self):
+        """See Language.source_extensions."""
+        return [".h"]
+
+    @property
+    def object_extensions(self):
+        """See Language.source_extensions."""
+        return [".o"]
+
+    def get_compilation_commands(self,
+                                 source_filenames, executable_filename,
+                                 for_evaluation=True):
+        """See Language.get_compilation_commands."""
+        command = ["/usr/bin/g++"]
+        if for_evaluation:
+            command += ["-DEVAL"]
+        command += ["-std=c++14", "-O2", "-pipe", "-static",
+                    "-s", "-o", executable_filename]
+        command += source_filenames
+        return [command]


### PR DESCRIPTION
Add a [specification file](https://cms.readthedocs.io/en/v1.3/Configuring%20a%20contest.html#programming-languages) for the C++ 14 standard.
The flag `std=c++14` is valid in `g++` [from version `5.2` and on](https://gcc.gnu.org/onlinedocs/gcc-5.2.0/gcc/C-Dialect-Options.html#C-Dialect-Options) (the ioi server uses a more recent version).
The added file is a copy of to the `c++11` file, with the relevant changes to the standard version.